### PR TITLE
Expose the flat buffer builder object of an event.

### DIFF
--- a/zeq/event.cpp
+++ b/zeq/event.cpp
@@ -29,6 +29,11 @@ uint64_t Event::getType() const
     return _impl->type;
 }
 
+flatbuffers::FlatBufferBuilder &Event::getFlatBuffer()
+{
+    return _impl->fbb;
+}
+
 size_t Event::getSize() const
 {
     return _impl->getSize();

--- a/zeq/event.h
+++ b/zeq/event.h
@@ -9,6 +9,11 @@
 #include <zeq/api.h>
 #include <zeq/types.h>
 
+namespace flatbuffers
+{
+    class FlatBufferBuilder;
+}
+
 namespace zeq
 {
 namespace detail { class Subscriber; class Event; }
@@ -35,6 +40,9 @@ public:
 
     /** @return the type of this event */
     ZEQ_API uint64_t getType() const;
+
+    /** @return the flat buffer builder */
+    ZEQ_API flatbuffers::FlatBufferBuilder& getFlatBuffer();
 
     /** @internal @return the size in bytes of the serialized data */
     ZEQ_API size_t getSize() const;


### PR DESCRIPTION
This is needed to create vocabularies outside zeq.
