### PR TITLE
Workaround for the VS10 min macro problem

### DIFF
--- a/zeq/receiver.cpp
+++ b/zeq/receiver.cpp
@@ -47,7 +47,7 @@ public:
 
         // Never fully block. Give receivers a chance to update, e.g., to check
         // for new connections from zeroconf (#20)
-        const uint32_t block = std::min( 1000u, timeout / 10 );
+        const uint32_t block = ( std::min )( 1000u, timeout / 10 );
 
         lunchbox::Clock timer;
         while( true )
@@ -58,7 +58,7 @@ public:
             const uint64_t elapsed = timer.getTime64();
             long wait = 0;
             if( elapsed < timeout )
-                wait = std::min( timeout - uint32_t( elapsed ), block );
+                wait = ( std::min )( timeout - uint32_t( elapsed ), block );
 
             if( _receive( wait ))
                 return true;


### PR DESCRIPTION
VS10 has a min macro that gives a building error. Placing parenthesis around std::min gives a clean workaround.