### PR TITLE
Fix MSVC build

### DIFF
--- a/.gitexternals
+++ b/.gitexternals
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-# CMake/common https://github.com/Eyescale/CMake.git cc04b98
+# CMake/common https://github.com/Eyescale/CMake.git e4b778b

--- a/zeq/receiver.h
+++ b/zeq/receiver.h
@@ -88,7 +88,6 @@ protected:
     void* getZMQContext(); //!< @internal returns the ZeroMQ context
 
 private:
-    Receiver( const Receiver& ) = delete;
     Receiver& operator=( const Receiver& ) = delete;
 
     std::shared_ptr< detail::Receiver > const _impl;


### PR DESCRIPTION
Fixes the error caused by warning C4521: 'zeq::Receiver' : multiple copy
constructors specified