### PR TITLE
Relax and document thread-safety for JSON parsing

### DIFF
--- a/tests/serialization.cpp
+++ b/tests/serialization.cpp
@@ -88,7 +88,9 @@ BOOST_AUTO_TEST_CASE(test_invalid_event_registration)
     const zeq::uint128_t eventType( 42 );
     zeq::vocabulary::registerEvent( eventType, schema );
 
-    BOOST_CHECK_THROW( zeq::Event( zeq::uint128_t( 42 )), std::runtime_error );
+    zeq::Event event( zeq::uint128_t( 42 ));
+    BOOST_CHECK_THROW( zeq::vocabulary::deserializeJSON( event ),
+                       std::runtime_error );
 }
 
 BOOST_AUTO_TEST_CASE(test_serialization)

--- a/zeq/detail/event.h
+++ b/zeq/detail/event.h
@@ -1,12 +1,10 @@
 
-/* Copyright (c) 2014-2015, Human Brain Project
- *                          Daniel Nachbaur <daniel.nachbaur@epfl.ch>
+/* Copyright (c) 2014, Human Brain Project
+ *                     Daniel Nachbaur <daniel.nachbaur@epfl.ch>
  */
 
 #ifndef ZEQ_DETAIL_EVENT_H
 #define ZEQ_DETAIL_EVENT_H
-
-#include "vocabulary.h"
 
 #include <zeq/types.h>
 #include <zeq/event.h>
@@ -25,13 +23,7 @@ class Event
 public:
     Event( const uint128_t& type_ )
         : type( type_ )
-    {
-        const std::string& schema = vocabulary::detail::getSchema( type );
-
-        // populate parser with schema from type
-        if( !schema.empty() && !parser.Parse( schema.c_str( )))
-            LBTHROW( std::runtime_error( parser.error_ ));
-    }
+    {}
 
     size_t getSize() const
     {

--- a/zeq/detail/vocabulary.h
+++ b/zeq/detail/vocabulary.h
@@ -33,8 +33,6 @@ std::string deserializeJSON( const zeq::Event& event );
 
 void registerEvent( const uint128_t& type, const std::string& schema );
 
-const std::string& getSchema( const uint128_t& type );
-
 }
 }
 }

--- a/zeq/event.cpp
+++ b/zeq/event.cpp
@@ -54,9 +54,4 @@ flatbuffers::Parser& Event::getParser()
     return _impl->parser;
 }
 
-const flatbuffers::Parser& Event::getParser() const
-{
-    return _impl->parser;
-}
-
 }

--- a/zeq/event.h
+++ b/zeq/event.h
@@ -11,7 +11,7 @@
 
 namespace zeq
 {
-namespace detail { class Subscriber; class Event; }
+namespace detail{ class Subscriber; class Event; }
 
 /**
  * An event is emitted by a Publisher to notify Subscriber of a change.
@@ -28,7 +28,6 @@ public:
      * Construct a new event of the given type
      *
      * @param type the desired event type
-     * @throw std::runtime_error when an invalid schema is registered
      * @sa vocabulary::registerEvent
      */
     ZEQ_API explicit Event( const uint128_t& type );
@@ -52,7 +51,6 @@ public:
 
     /** @internal @return serialization specific implementation */
     ZEQ_API flatbuffers::Parser& getParser();
-    ZEQ_API const flatbuffers::Parser& getParser() const;
 
 private:
     Event( const Event& ) = delete;

--- a/zeq/vocabulary.h
+++ b/zeq/vocabulary.h
@@ -25,6 +25,8 @@ namespace zeq
 namespace vocabulary
 {
 
+/** @name Builtin Events */
+//@{
 ZEQ_API Event serializeEcho( const std::string& message );
 ZEQ_API std::string deserializeEcho( const Event& event );
 
@@ -59,7 +61,22 @@ ZEQ_API Event serializeRequest( const uint128_t& eventType );
  * @return an uint128_t to identify the zeq event that should be published.
  */
 ZEQ_API uint128_t deserializeRequest( const Event& event );
+//@}
 
+/**
+ * @name JSON/binary event translation.
+ *
+ * These functions are not thread-safe, that is, calling registerEvent()
+ * concurrently with any of the other functions in this group needs external
+ * serialization.
+ */
+//@{
+/** Establish a type to schema mapping for (de)serialization from/to JSON.
+ *
+ * @param type the type of the event.
+ * @param schema the schema as string of the event.
+ */
+ZEQ_API void registerEvent( const uint128_t& type, const std::string& schema );
 
 /** Serialize an event from JSON to a zeq::Event.
  *
@@ -73,7 +90,8 @@ ZEQ_API uint128_t deserializeRequest( const Event& event );
  * @param json JSON-formatted string containing the values for schema-defined
  *             keys
  * @return the serialized zeq::Event from the given JSON string.
- * @throw std::runtime_error when the parsing of the given JSON fails
+ * @throw std::runtime_error when the parsing of the given JSON fails or the
+ *        given event is not registered.
  */
 ZEQ_API Event serializeJSON( const uint128_t& type, const std::string& json );
 
@@ -87,15 +105,10 @@ ZEQ_API Event serializeJSON( const uint128_t& type, const std::string& json );
  * @sa serializeJSON
  * @param event the zeq::Event to deserialize into JSON.
  * @return the deserialized JSON string from the given zeq::Event.
+ * @throw std::runtime_error when the given event is not registered.
  */
 ZEQ_API std::string deserializeJSON( const Event& event );
-
-/** Establish a type to schema mapping for (de)serialization from/to JSON.
- *
- * @param type the type of the event.
- * @param schema the schema as string of the event.
- */
-ZEQ_API void registerEvent( const uint128_t& type, const std::string& schema );
+//@}
 
 }
 }


### PR DESCRIPTION
Stumbled upon this when creating independent events in parallel: When
their types are not registered, the (unneeded) schema parsing in the
event ctor called in parallel unordered_map::operator [] which is not
thread safe.

Moved schema parsing to JSON code and made getSchema() "const"