### PR TITLE
Added CellSetBinaryOp to HBP vocabulary

### DIFF
--- a/tests/hbp/serialization.cpp
+++ b/tests/hbp/serialization.cpp
@@ -95,3 +95,34 @@ BOOST_AUTO_TEST_CASE( imageJPEGEvent )
                                    deserializedImage.getDataPtr(),
                                    deserializedImage.getDataPtr() + size );
 }
+
+BOOST_AUTO_TEST_CASE( cellSetBinaryOp )
+{
+  zeq::hbp::data::CellSetBinaryOp cellSet ({ 0, 2, 4, 6 },
+                                           { 1, 3, 5, 7 },
+                                           zeq::hbp::CellSetOpType::
+                                           CellSetOpType_SYNAPTIC_PROJECTION);
+//  cellSet.first = ;
+//  cellSet.second = ;
+//  cellSet.operation =
+//      zeq::hbp::CellSetOpType::CellSetOpType_SYNAPTIC_PROJECTION;
+
+  const zeq::Event& cellSetBinaryOpEvent =
+      zeq::hbp::serializeCellSetBinaryOp( cellSet );
+
+  zeq::hbp::data::CellSetBinaryOp deserializedCellSetBinaryOp =
+      zeq::hbp::deserializeCellSetBinaryOp( cellSetBinaryOpEvent );
+
+  BOOST_CHECK_EQUAL( cellSet.operation,
+                     deserializedCellSetBinaryOp.operation);
+
+  BOOST_CHECK_EQUAL_COLLECTIONS( cellSet.first.begin( ),
+                                 cellSet.first.end( ),
+                                 deserializedCellSetBinaryOp.first.begin( ),
+                                 deserializedCellSetBinaryOp.first.end( ));
+
+  BOOST_CHECK_EQUAL_COLLECTIONS( cellSet.second.begin( ),
+                                 cellSet.second.end( ),
+                                 deserializedCellSetBinaryOp.second.begin( ),
+                                 deserializedCellSetBinaryOp.second.end( ));
+}

--- a/zeq/hbp/CMakeLists.txt
+++ b/zeq/hbp/CMakeLists.txt
@@ -8,6 +8,7 @@ flatbuffers_generate_c_headers(HBP_FBS
   detail/imageJPEG.fbs
   detail/lookupTable1D.fbs
   detail/selections.fbs
+  detail/cellSetBinaryOp.fbs
 )
 
 set(ZEQHBP_PUBLIC_HEADERS vocabulary.h ${HBP_FBS_ZEQ_OUTPUTS})

--- a/zeq/hbp/detail/cellSetBinaryOp.fbs
+++ b/zeq/hbp/detail/cellSetBinaryOp.fbs
@@ -1,0 +1,16 @@
+// Copyright (c) 2015, Human Brain Project
+//                      Sergio E. Galindo <sergio.galindo@urjc.es>
+//                     
+
+namespace zeq.hbp;
+
+enum CellSetOpType : byte { SYNAPTIC_PROJECTION = 0 }
+
+table CellSetBinaryOp
+{
+  first:[uint];
+  second:[uint];
+  operation:CellSetOpType;
+}
+
+root_type CellSetBinaryOp;

--- a/zeq/hbp/vocabulary.cpp
+++ b/zeq/hbp/vocabulary.cpp
@@ -154,5 +154,37 @@ std::vector< uint8_t > deserializeLookupTable1D( const Event& event )
     return deserializeVector( data->lut( ));
 }
 
+Event serializeCellSetBinaryOp( const data::CellSetBinaryOp& cellSetBinaryOp )
+{
+  zeq::Event event( EVENT_CELLSETBINARYOP );
+
+  flatbuffers::FlatBufferBuilder& fbb = event.getFBB( );
+
+  auto firstData = fbb.CreateVector( cellSetBinaryOp.first );
+  auto secondData = fbb.CreateVector( cellSetBinaryOp.second );
+
+  CellSetBinaryOpBuilder builder( fbb );
+  builder.add_first( firstData );
+  builder.add_second( secondData );
+  builder.add_operation( cellSetBinaryOp.operation );
+
+  fbb.Finish( builder.Finish( ));
+
+  return event;
+}
+
+data::CellSetBinaryOp
+deserializeCellSetBinaryOp( const Event& event )
+{
+  data::CellSetBinaryOp result;
+
+  auto data = GetCellSetBinaryOp( event.getData( ));
+  result.first = deserializeVector( data->first( ));
+  result.second = deserializeVector( data->second( ));
+  result.operation = data->operation( );
+
+  return result;
+}
+
 }
 }

--- a/zeq/hbp/vocabulary.h
+++ b/zeq/hbp/vocabulary.h
@@ -16,6 +16,8 @@
 #include <zeq/hbp/imageJPEG_zeq_generated.h>
 #include <zeq/hbp/lookupTable1D_zeq_generated.h>
 #include <zeq/hbp/selections_zeq_generated.h>
+#include <zeq/hbp/cellSetBinaryOp_zeq_generated.h>
+#include <zeq/hbp/cellSetBinaryOp_generated.h>
 
 namespace zeq
 {
@@ -67,6 +69,32 @@ struct ImageJPEG
 private:
     const uint32_t _sizeInBytes;
     const uint8_t* _data;
+};
+
+
+/**
+ * Stores two unsigned int vectors and an operation flag.
+ *
+ * This class stores a couple of unsigned int vectors
+ * and an operation flag indicating the operation type of the event.
+ *
+ */
+struct CellSetBinaryOp
+{
+public:
+
+  CellSetBinaryOp( ): operation((zeq::hbp::CellSetOpType) 0 ) { }
+  CellSetBinaryOp( const std::vector< unsigned int >& first_,
+                  const std::vector< unsigned int >& second_,
+                  zeq::hbp::CellSetOpType operation_ )
+  : first( first_ )
+  , second( second_ )
+  , operation( operation_ )
+  { }
+
+  std::vector< unsigned int > first;
+  std::vector< unsigned int > second;
+  zeq::hbp::CellSetOpType operation;
 };
 
 }
@@ -174,6 +202,22 @@ ZEQ_API Event serializeImageJPEG( const data::ImageJPEG& image );
  */
 ZEQ_API data::ImageJPEG deserializeImageJPEG( const Event& event );
 
+/**
+ * Serialize the given CellSetBinaryOp into an Event of type
+ * EVENT_CELLSETBINARYOP.
+ * @param cellSetBinaryOp the CellSetBinaryOp to be serialized.
+ * @return the serialized event.
+ */
+ZEQ_API
+Event serializeCellSetBinaryOp( const data::CellSetBinaryOp& cellSetBinaryOp );
+
+/**
+ * Deserialize the given EVENT_CELLSETBINARYOP event into a CellSetBinaryOp
+ * consisting of a couple of std::vector of unsigned int and the operation type.
+ * @param event the event product of serializeCellSetBinaryOp.
+ * @return the deserialized CellSetBinaryOp.
+ */
+ZEQ_API data::CellSetBinaryOp deserializeCellSetBinaryOp( const Event& event );
 
 }
 }


### PR DESCRIPTION
This includes the CellSetBinaryOp serialization into the HBP vocabulary, consisting of a pair of unsigned integer vectors and the specified operation.