### PR TITLE
Removing the enum for cell set operations from cellSetBinaryOp.fbs

### DIFF
--- a/tests/hbp/serialization.cpp
+++ b/tests/hbp/serialization.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( cellSetBinaryOp )
 {
   zeq::hbp::data::CellSetBinaryOp cellSet (
       { 0, 2, 4, 6 }, { 1, 3, 5, 7 },
-      zeq::hbp::CellSetOpType::CellSetOpType_SYNAPTIC_PROJECTION);
+      zeq::hbp::CELLSETOP_SYNAPTIC_PROJECTIONS);
 
   const zeq::Event& cellSetBinaryOpEvent =
       zeq::hbp::serializeCellSetBinaryOp( cellSet );

--- a/zeq/hbp/CMakeLists.txt
+++ b/zeq/hbp/CMakeLists.txt
@@ -4,14 +4,14 @@
 
 flatbuffers_generate_c_headers(HBP_FBS
   detail/camera.fbs
+  detail/cellSetBinaryOp.fbs
   detail/frame.fbs
   detail/imageJPEG.fbs
   detail/lookupTable1D.fbs
   detail/selections.fbs
-  detail/cellSetBinaryOp.fbs
 )
 
-set(ZEQHBP_PUBLIC_HEADERS vocabulary.h ${HBP_FBS_ZEQ_OUTPUTS})
+set(ZEQHBP_PUBLIC_HEADERS enums.h vocabulary.h ${HBP_FBS_ZEQ_OUTPUTS})
 set(ZEQHBP_SOURCES vocabulary.cpp)
 set(ZEQHBP_LINK_LIBRARIES PUBLIC zeq)
 if(MSVC)

--- a/zeq/hbp/detail/cellSetBinaryOp.fbs
+++ b/zeq/hbp/detail/cellSetBinaryOp.fbs
@@ -4,13 +4,11 @@
 
 namespace zeq.hbp;
 
-enum CellSetOpType : byte { SYNAPTIC_PROJECTION = 0 }
-
 table CellSetBinaryOp
 {
   first:[uint];
   second:[uint];
-  operation:CellSetOpType;
+  operation:uint; // zeq::hbp::CellSetBinaryOpType
 }
 
 root_type CellSetBinaryOp;

--- a/zeq/hbp/enums.h
+++ b/zeq/hbp/enums.h
@@ -1,0 +1,24 @@
+
+/* Copyright (c) 2014-2015, Human Brain Project
+ *                          Juan Hernando <jhernando@fi.upm.es>
+ */
+
+#ifndef ZEQ_HBP_ENUMS_H
+#define ZEQ_HBP_ENUMS_H
+
+namespace zeq
+{
+namespace hbp
+{
+
+/** Possible operations for a CellSetBinaryOp event */
+enum CellSetBinaryOpType
+{
+    /** Requests the display of the synaptic pathways from a pre-synaptic
+        target to a post-synaptic target. */
+    CELLSETOP_SYNAPTIC_PROJECTIONS = 0
+};
+
+}
+}
+#endif

--- a/zeq/hbp/vocabulary.cpp
+++ b/zeq/hbp/vocabulary.cpp
@@ -7,6 +7,7 @@
 #include "vocabulary.h"
 
 #include <zeq/hbp/camera_generated.h>
+#include <zeq/hbp/cellSetBinaryOp_generated.h>
 #include <zeq/hbp/frame_generated.h>
 #include <zeq/hbp/imageJPEG_generated.h>
 #include <zeq/hbp/selections_generated.h>
@@ -182,7 +183,7 @@ deserializeCellSetBinaryOp( const Event& event )
 
   return data::CellSetBinaryOp( deserializeVector( data->first( )),
                                 deserializeVector( data->second( )),
-                                data->operation( ));
+                                CellSetBinaryOpType(data->operation( )));
 }
 
 }

--- a/zeq/hbp/vocabulary.h
+++ b/zeq/hbp/vocabulary.h
@@ -11,13 +11,14 @@
 #include <zeq/types.h>
 #include <zeq/api.h>
 
+#include <zeq/hbp/enums.h>
+
 #include <zeq/hbp/camera_zeq_generated.h>
+#include <zeq/hbp/cellSetBinaryOp_zeq_generated.h>
 #include <zeq/hbp/frame_zeq_generated.h>
 #include <zeq/hbp/imageJPEG_zeq_generated.h>
 #include <zeq/hbp/lookupTable1D_zeq_generated.h>
 #include <zeq/hbp/selections_zeq_generated.h>
-#include <zeq/hbp/cellSetBinaryOp_zeq_generated.h>
-#include <zeq/hbp/cellSetBinaryOp_generated.h>
 
 namespace zeq
 {
@@ -87,17 +88,17 @@ struct CellSetBinaryOp
 {
 public:
 
-  CellSetBinaryOp( ): operation((zeq::hbp::CellSetOpType) 0 ) { }
-  CellSetBinaryOp( const uint32_ts& first_, const uint32_ts& second_,
-                   zeq::hbp::CellSetOpType operation_ )
-  : first( first_ )
-  , second( second_ )
-  , operation( operation_ )
-  { }
+    CellSetBinaryOp() {}
+    CellSetBinaryOp( const uint32_ts& first_, const uint32_ts& second_,
+                     CellSetBinaryOpType operation_ )
+        : first( first_ )
+        , second( second_ )
+        , operation( operation_ )
+    {}
 
-  uint32_ts first;
-  uint32_ts second;
-  zeq::hbp::CellSetOpType operation;
+    uint32_ts first;
+    uint32_ts second;
+    CellSetBinaryOpType operation;
 };
 
 }


### PR DESCRIPTION
This was requiring to include the flatbuffers header in the vocabulary header,
which in turn makes Flatbuffers leak. The enum has been moved to the C++ side.
The previous enum was not kept to avoid a redundancy.