### PR TITLE
Add support for host:0 in URIs (OS-chosen port)

### DIFF
--- a/zeq/detail/broker.h
+++ b/zeq/detail/broker.h
@@ -14,11 +14,12 @@ std::string buildZmqURI( std::string host, const uint16_t port )
 {
     if( host.empty( ))
         host = "*";
-    if( host != "*" && port == 0 ) // zmq does not support host:0
-        throw std::runtime_error(
-            "OS-chosen port not supported with hostname " + host );
 
-    return std::string( "tcp://" ) + host + ":" + std::to_string( int( port ));
+    const std::string tcpURI( "tcp://" + host );
+    if( port == 0 ) // zmq expects host:* instead of host:0
+        return tcpURI + ":*";
+
+    return tcpURI + ":" + std::to_string( int( port ));
 }
 
 std::string buildZmqURI( const servus::URI& uri )


### PR DESCRIPTION
zmq expects host:*