### PR TITLE
Added static_cast to int and missing macros

### DIFF
--- a/zeroeq/detail/sender.h
+++ b/zeroeq/detail/sender.h
@@ -32,7 +32,7 @@ public:
     void addSockets(std::vector<zeroeq::detail::Socket>& entries);
 
     const std::string& getSession() const { return _session; }
-    static uint128_t& getUUID();
+    ZEROEQ_API static uint128_t& getUUID();
 
     URI uri;
     zmq::SocketPtr socket;

--- a/zeroeq/http/requestHandler.cpp
+++ b/zeroeq/http/requestHandler.cpp
@@ -22,12 +22,15 @@ namespace http
 {
 namespace
 {
-int _getContentLength(const HTTPServer::request& request)
+size_t _getContentLength(const HTTPServer::request& request)
 {
     for (const auto& i : request.headers)
     {
         if (i.name == "Content-Length")
-            return std::stoi(i.value);
+        {
+            int size = std::stoi(i.value);
+            return (size > 0) ? size : 0;
+        }
     }
     return 0;
 }
@@ -216,7 +219,7 @@ private:
     const HTTPServer::request& _request;
     void* _socket;
     std::string _body;
-    int _size = 0;
+    size_t _size = 0;
 };
 } // anonymous namespace
 

--- a/zeroeq/http/server.h
+++ b/zeroeq/http/server.h
@@ -56,7 +56,7 @@ public:
     ZEROEQHTTP_API Server(const URI& uri, Receiver& shared);
     ZEROEQHTTP_API explicit Server(const URI& uri);
     ZEROEQHTTP_API explicit Server(Receiver& shared);
-    explicit Server(Server& shared)
+    ZEROEQHTTP_API explicit Server(Server& shared)
         : Server(static_cast<Receiver&>(shared))
     {
     }
@@ -112,7 +112,7 @@ public:
      * @return true if subscription was successful, false otherwise
      * @sa Request
      */
-    bool handle(Method method, const std::string& endpoint, RESTFunc func);
+    ZEROEQHTTP_API bool handle(Method method, const std::string& endpoint, RESTFunc func);
 
     /** @name Object registration for PUT and GET requests */
     //@{

--- a/zeroeq/monitor.h
+++ b/zeroeq/monitor.h
@@ -39,7 +39,7 @@ private:
     Monitor& operator=(const Monitor&) = delete;
 
     // Receiver API
-    void addSockets(std::vector<zeroeq::detail::Socket>& entries) final;
-    bool process(zeroeq::detail::Socket& socket) final;
+    ZEROEQ_API void addSockets(std::vector<zeroeq::detail::Socket>& entries) final;
+    ZEROEQ_API bool process(zeroeq::detail::Socket& socket) final;
 };
 }

--- a/zeroeq/subscriber.h
+++ b/zeroeq/subscriber.h
@@ -103,11 +103,11 @@ public:
     /** Destroy this subscriber and withdraw any subscriptions. */
     ZEROEQ_API ~Subscriber();
 
-    explicit Subscriber(const URI& uri) //!< @deprecated
+    ZEROEQ_API explicit Subscriber(const URI& uri) //!< @deprecated
         : Subscriber(URIs{uri})
     {
     }
-    Subscriber(const URI& uri, Receiver& shared) //!< @deprecated
+    ZEROEQ_API Subscriber(const URI& uri, Receiver& shared) //!< @deprecated
         : Subscriber(URIs{uri}, shared)
     {
     }


### PR DESCRIPTION
Hello, I'm Gonzalo Bayo, from the group working back in URJC/UPM with Pablo Toharia.
Right now I would like to use ZeroEQ in a custom C++ project in Windows (VC14) and '/ZeroEQ/zeroeq/http/requestHandler.cpp' doesn't compile. 
I have got the error: C4267: '-=' : conversion from 'size_t' to 'int', possible loss of data.
This error can be fixed casting 'size_t' to 'int' in the same file.
Also, test projects are not linking successfully ( errors LNK2001, LNK2019 and LNK1120 ) due a missing macros in some functions of ZeroEQ and ZeroEQHTTP projects.
This error can be fixed using appropriated macros (ZEROEQ_API and ZEROEQHTTP_API) in each case.
Regards